### PR TITLE
Build Windows binary packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rbnacl", github: 'cryptosphere/rbnacl'
+gem "rbnacl", git: 'https://github.com/cryptosphere/rbnacl.git'
 
 group :development, :test do
   gem "rspec", "~> 3"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,52 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'rake/extensiontask'
 
 RSpec::Core::RakeTask.new
 
 task default: :spec
+
+MAKE = ENV['MAKE'] || ENV['make'] || "make"
+RUBY_CC_VERSION = ENV['RUBY_CC_VERSION'] || '2.3.0'
+
+desc "Build Windows binary packages"
+task 'gem:windows' do
+  require 'rake_compiler_dock'
+  if File.exist? "vendor/libsodium/Makefile"
+    RakeCompilerDock.sh "cd vendor/libsodium && #{MAKE} clean"
+  end
+  sh "bundle package"   # Avoid repeated downloads of gems by using gem files from the host.
+  RakeCompilerDock.sh "bundle --local && RUBY_CC_VERSION=#{RUBY_CC_VERSION} rake cross native gem"
+end
+
+spec = Gem::Specification.load("rbnacl-libsodium.gemspec")
+
+PLATFORMS = ['x86-mingw32', 'x64-mingw32']
+Rake::ExtensionTask.new("fake_ext", spec) do |ext|
+  ext.ext_dir = 'ext/rbnacl'
+  ext.cross_compile = true
+  ext.cross_platform = PLATFORMS
+  ext.cross_config_options << {
+    'x86-mingw32' => '--with-host=i686-w64-mingw32',
+    'x64-mingw32' => '--with-host=x86_64-w64-mingw32'
+  }
+  ext.cross_compiling do |gem_spec|
+    gem_spec.files.reject! { |f| /lib\/fake_ext\.so\Z/ =~ f }
+    stage_path = "#{ext.tmp_dir}/#{gem_spec.platform}/stage"
+    gem_spec.files += Dir["#{stage_path}/vendor/libsodium/dist/**/*"].map do |stage|
+      gem_path = stage.sub(stage_path + "/", "")
+      # define empty task to skip copy from vendor/libsodium/dist/*
+      task stage
+      task gem_path
+      gem_path
+    end
+    gem_spec.post_install_message = "You installed the binary version of this gem!"
+  end
+end
+
+PLATFORMS.each do |platf|
+  copy_task = "copy:fake_ext:#{platf}:#{RUBY_CC_VERSION}"
+  if Rake::Task.task_defined?(copy_task)
+    Rake::Task[copy_task].clear_actions
+  end
+end

--- a/ext/rbnacl/extconf.rb
+++ b/ext/rbnacl/extconf.rb
@@ -1,3 +1,5 @@
+require 'mkmf'
+
 def sys(cmd)
   puts " -- #{cmd}"
   unless ret = system(cmd)
@@ -14,13 +16,26 @@ clean:
 \t@echo "Nothing to do"
 MAKEFILE
 
+HOST = arg_config("--host")
+OPTIONS = []
+if HOST
+  OPTIONS << "--host=#{HOST}"
+end
+
 CWD = File.expand_path(File.dirname(__FILE__))
 LIBSODIUM_DIR = File.expand_path(File.join(CWD, '..', '..', 'vendor', 'libsodium'))
 MAKE = ENV['MAKE'] || ENV['make'] || "make"
+if HOST
+  # install to the stage directory for rake-compiler
+  DIST = File.expand_path(File.join(CWD, '..', '..', 'tmp', RUBY_PLATFORM, 'stage', 'vendor', 'libsodium', 'dist'))
+else
+  DIST = "#{LIBSODIUM_DIR}/dist"
+end
 
 Dir.chdir(LIBSODIUM_DIR) do
   # sh is required to run configure on Windows
-  sys("sh -c \"./configure --prefix=#{LIBSODIUM_DIR}/dist\"")
+  sys("sh -c \"./configure --prefix=#{DIST} #{OPTIONS.join(' ')}\"")
+  sys("#{MAKE} clean") if HOST
   sys(MAKE)
   sys("#{MAKE} install")
 end

--- a/lib/rbnacl/libsodium.rb
+++ b/lib/rbnacl/libsodium.rb
@@ -12,7 +12,7 @@ module RbNaCl
       def sodiumlib_glob
         case RUBY_DESCRIPTION
         when /darwin/ then 'libsodium*.dylib'
-        when /Windows|(win|mingw)32/ then 'libsodium*.dll'
+        when /Windows|(win|mingw)32/ then '../bin/libsodium*.dll'
         when /openbsd/ then 'libsodium*.so.*'
         else 'libsodium*.so'
         end

--- a/rbnacl-libsodium.gemspec
+++ b/rbnacl-libsodium.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", ">= 10"
+  spec.add_development_dependency 'rake-compiler', '~> 0.9.7'
+  spec.add_development_dependency 'rake-compiler-dock', '~> 0.5.2'
 end


### PR DESCRIPTION
We can cross compile Windows binary on docker using
[rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) and [rake-compiler](https://github.com/rake-compiler/rake-compiler).
`rake gem:windows` will pull docker image, cross compile and
create the following packages in `pkg` directory.
- rbnacl-libsodium-x.x.x-x64-mingw32.gem
- rbnacl-libsodium-x.x.x-x86-mingw32.gem
