### PR TITLE
Make compatible with 64 bit.

### DIFF
--- a/lib/rbnacl/libsodium.rb
+++ b/lib/rbnacl/libsodium.rb
@@ -2,7 +2,10 @@ require "rbnacl/libsodium/version"
 
 module RbNaCl
   module Libsodium
-    sodiumlib_dir = File.expand_path("../../../vendor/libsodium/dist/lib/", __FILE__)
+    sodiumlib32_dir = File.expand_path("../../../vendor/libsodium/dist/lib/", __FILE__)
+    sodiumlib64_dir = File.expand_path("../../../vendor/libsodium/dist/lib64/", __FILE__)
+    libsodium_dirs  = [sodiumlib32_dir, sodiumlib64_dir]
+    sodiumlib_dir   = libsodium_dirs.select { |dir| Dir.exist?(dir) }.first
 
     sodiumlib_glob = case RUBY_DESCRIPTION
     when /darwin/ then "libsodium*.dylib"


### PR DESCRIPTION
This fixes an "ffi_lib': Could not open library 'lib.so': lib.so: cannot open shared object file: No such file or directory (LoadError)" error, if the ..vendor/libsodium/dist/lib folder is not found with libsodium.so. In some systems, libsodium.so is in the ..vendor/libsodium/dist/lib64 directory, not ..vendor/libsodium/dist/lib.