### PR TITLE
Support OpenBSD

### DIFF
--- a/lib/rbnacl/libsodium.rb
+++ b/lib/rbnacl/libsodium.rb
@@ -7,6 +7,7 @@ module RbNaCl
     sodiumlib_glob = case RUBY_DESCRIPTION
     when /darwin/ then "libsodium*.dylib"
     when /Windows|(win|mingw)32/ then "libsodium*.dll"
+    when /openbsd/ then "libsodium*.so.*"
     else "libsodium*.so"
     end
 


### PR DESCRIPTION
OpenBSD builds libsodium.so.19.1 (for example), so the libsodium*.so won't match.