### PR TITLE
drop support for ruby lower than 2.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
+  - 2.2.6
   - 2.3.0
   - ruby-head
-  - jruby
-  - jruby-9.0.4.0
+  - jruby-9.1.14.0
   - jruby-head
   - rbx-2
 

--- a/rbnacl-libsodium.gemspec
+++ b/rbnacl-libsodium.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/rbnacl/extconf.rb']
 
   spec.add_runtime_dependency "rbnacl", ">= 3.0.1"
+  spec.required_ruby_version = '>= 2.2.6'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", ">= 10"


### PR DESCRIPTION
rbnacl-5.0.0 requires ruby version >= 2.2.6